### PR TITLE
Update Mastering JBTD Interviews course link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Awesome Jobs to Be Done List
 - **[Basic Timeline Structure from Rewired Group](http://jobstobedone.org/wp-content/uploads/2013/01/jtbd-timeline.png)**
 
 #### Courses
-- **[Mastering Jobs to Be Done Interviews](https://www.udemy.com/mastering-jobs-to-be-done-interviews/)** Udemy course
+- **[Mastering Jobs to Be Done Interviews](http://learn.jobstobedone.org/courses/JTBDinterviews)** online course
 
 #### Conferences
 - **[Business of Software](http://businessofsoftware.org/)**


### PR DESCRIPTION
The course no longer appears to be available via the Udemy link, instead it looks like it's moved to this new link. :]
